### PR TITLE
Add docker & run integration test inside the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+node_modules
+
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+*.swp
+
+pids
+logs
+results
+tmp
+
+# API keys and secrets
+.env
+
+# Dependency directory
+node_modules
+bower_components
+
+# Editors
+.idea
+*.iml
+.vscode
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Configuration files
+config/production.json
+config/staging.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:9-alpine
 
-RUN apk --no-cache add bash python build-base
+RUN apk --no-cache add bash git
+# python build-base
 # remove python and build-base when grpc-prebuilt will be up again
 
 ADD . /opt/orbs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:9-alpine
+
+RUN apk --no-cache add bash python build-base
+# remove python and build-base when grpc-prebuilt will be up again
+
+ADD . /opt/orbs
+
+WORKDIR /opt/orbs
+
+RUN npm install -g typescript@2.6.2
+
+RUN ./install.sh
+
+RUN find . -name package-lock.json -delete
+
+RUN ./build.sh
+
+CMD node simulate/src/index.js transaction-gossip

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN find . -name package-lock.json -delete
 
 RUN ./build.sh
 
+RUN cd e2e && ./build.sh
+
 CMD node simulate/src/index.js transaction-gossip

--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ This wrapper project will set up a full working environment including all sub pr
 
 * This will watch for file changes on all typescript sub projects and recompile automatically.
 * Work directly on all sub projects inside the folder `./projects`, they're separate git repos.
+
+## Run inside of Docker
+
+`docker-compose up` will build an image and start a simulation of `transaction-gossip` topography.

--- a/build/src/build-ts.js
+++ b/build/src/build-ts.js
@@ -4,7 +4,7 @@ const projects = require('../../config/projects.json');
 require('colors');
 
 async function main() {
-  Object.keys(projects).forEach((projectName) => {
+  projects.order.forEach((projectName) => {
     const project = projects[projectName];
     const projectPath = path.resolve(__dirname, '../../projects/', projectName);
     if (project.runtime === 'typescript' || project.runtime === 'protobuf') {

--- a/build/src/rebuild-ts.js
+++ b/build/src/rebuild-ts.js
@@ -19,7 +19,7 @@ function changeTime(filePath) {
 }
 
 async function main() {
-  Object.keys(projects).forEach((projectName) => {
+  projects.order.forEach((projectName) => {
     const project = projects[projectName];
     const projectPath = path.resolve(__dirname, '../../projects/', projectName);
     if (changeTime(`${projectPath}/${srcDirs[project.runtime]}`) <= changeTime(`${projectPath}/dist`)) {

--- a/build/src/watch-ts.js
+++ b/build/src/watch-ts.js
@@ -4,7 +4,7 @@ const projects = require('../../config/projects.json');
 require('colors');
 
 async function main() {
-  Object.keys(projects).forEach((projectName) => {
+  projects.order.forEach((projectName) => {
     const project = projects[projectName];
     project.path = path.resolve(__dirname, '../../projects/', projectName);
     if (project.runtime === 'typescript') {

--- a/config/projects.json
+++ b/config/projects.json
@@ -45,5 +45,6 @@
     "runtime": "typescript",
     "service": "virtual-machine",
     "type": "service"
-  }
+  },
+  "order": ["architecture", "common-library-typescript", "block-storage-service-typescript", "chatter-service-typescript", "consensus-service-typescript", "gossip-service-typescript", "public-api-service-typescript", "state-storage-service-typescript", "transaction-pool-service-typescript", "virtual-machine-service-typescript"]
 }

--- a/config/projects.json
+++ b/config/projects.json
@@ -46,5 +46,16 @@
     "service": "virtual-machine",
     "type": "service"
   },
-  "order": ["architecture", "common-library-typescript", "block-storage-service-typescript", "chatter-service-typescript", "consensus-service-typescript", "gossip-service-typescript", "public-api-service-typescript", "state-storage-service-typescript", "transaction-pool-service-typescript", "virtual-machine-service-typescript"]
+  "order": [
+    "architecture",
+    "common-library-typescript",
+    "block-storage-service-typescript",
+    "chatter-service-typescript",
+    "consensus-service-typescript",
+    "gossip-service-typescript",
+    "public-api-service-typescript",
+    "state-storage-service-typescript",
+    "transaction-pool-service-typescript",
+    "virtual-machine-service-typescript"
+  ]
 }

--- a/config/topologies/transaction-gossip/node2/public-api.json
+++ b/config/topologies/transaction-gossip/node2/public-api.json
@@ -10,7 +10,7 @@
     },
     {
       "service": "consensus",
-      "endpoint": "0.0.0.0:51254"
+      "endpoint": "0.0.0.0:51154"
     },
     {
       "service": "virtual-machine",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,3 @@
+basic-simulation:
+  build: .
+  command: node simulate/src/index.js transaction-gossip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
 basic-simulation:
   build: .
   command: node simulate/src/index.js transaction-gossip
+#  volumes:
+#    - ./config:/opt/orbs/config

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,1 +1,5 @@
 Build project using the main [orbs-network](https://github.com/orbs-network/orbs-network) repo
+
+Run `docker-compose up` and then enter the container using `docker exec -ti orbsnetwork_basic-simulation_1 bash`.
+
+Inside the container run `cd e2e && npm test`.

--- a/e2e/src/simple-token-transfer.spec.ts
+++ b/e2e/src/simple-token-transfer.spec.ts
@@ -53,7 +53,7 @@ class OrbsClient {
     crypto: CryptoUtils;
     publicApiClient: types.PublicApiClient;
 
-    constructor(crypto: CryptoUtils, endpointAddress: string = "0.0.0.0:51151") {
+    constructor(crypto: CryptoUtils, endpointAddress: string = "0.0.0.0:51251") {
         this.crypto = crypto;
         this.publicApiClient = grpc.publicApiClient({endpoint: endpointAddress});
     }

--- a/projects/common-library-typescript/build.sh
+++ b/projects/common-library-typescript/build.sh
@@ -1,4 +1,5 @@
 npm link ../architecture
+# needs unsafe permissions to install node grpc extensions
 npm install --unsafe-perm grpc@1.8.4
 npm install
 npm run build

--- a/projects/common-library-typescript/build.sh
+++ b/projects/common-library-typescript/build.sh
@@ -1,3 +1,4 @@
 npm link ../architecture
+npm install --unsafe-perm grpc@1.8.4
 npm install
 npm run build


### PR DESCRIPTION
This PR does not deal with splitting up `simulate.js`, but it's in the pipeline down the road.

What can we do now:
- [x] Run `docker-compose up` and see a working docker image
- [x] Run integration test (`e2e`) inside the image

![screen shot 2018-01-22 at 11 55 09](https://user-images.githubusercontent.com/614125/35215497-1b2f48d0-ff6d-11e7-8668-417ada86551c.png)
