### PR TITLE
Initial support for AWS ECS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
    machine: true
    steps:
      - checkout
-     - run: docker build -t 506367651493.dkr.ecr.us-west-2.amazonaws.com/orbs-network:$CIRCLE_BRANCH .
-     - run: docker run -ti 506367651493.dkr.ecr.us-west-2.amazonaws.com/orbs-network:$CIRCLE_BRANCH bash -x test.sh
+     - run: docker build -t ${DOCKER_IMAGE}:$CIRCLE_BRANCH .
+     - run: docker run -ti ${DOCKER_IMAGE}:$CIRCLE_BRANCH bash -x test.sh
      - run: $(aws ecr get-login --no-include-email --region us-west-2)
-     - run: docker push 506367651493.dkr.ecr.us-west-2.amazonaws.com/orbs-network:$CIRCLE_BRANCH
+     - run: docker push ${DOCKER_IMAGE}:$CIRCLE_BRANCH

--- a/README.md
+++ b/README.md
@@ -89,3 +89,24 @@ This wrapper project will set up a full working environment including all sub pr
 ## Run inside of Docker
 
 `docker-compose up` will build an image and start a simulation of `transaction-gossip` topography.
+
+### Docker on AWS ECS
+
+Install `ecs-cli`
+
+```
+sudo curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest
+chmod +x /usr/local/bin/ecs-cli
+```
+
+If you want to pull images, log into AWS Elastic Container Registry.
+
+```
+$(aws ecr get-login --no-include-email --region us-west-2)
+```
+
+Deploy new stack:
+
+```
+ecs-cli compose --file docker-compose.staging.yml --ecs-params ecs-params.yml --region us-west-2 --cluster orbs-network-staging up
+```

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,3 +1,3 @@
 orbs-network:
-  image: 506367651493.dkr.ecr.us-west-2.amazonaws.com/orbs-network:master
+  image: ${DOCKER_IMAGE}:${DOCKER_TAG}
   mem_limit: 2147483648

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,3 @@
+orbs-network:
+  image: 506367651493.dkr.ecr.us-west-2.amazonaws.com/orbs-network:master
+  mem_limit: 2147483648

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -1,7 +1,7 @@
 version: 1
 task_definition:
   ecs_network_mode: none
-  task_role_arn: arn:aws:iam::506367651493:role/orbs-network 
+  task_role_arn: ${TASK_ROLE_ARN}
   memory: 2048
   memoryReservation: 2048
   task_size:

--- a/ecs-params.yml
+++ b/ecs-params.yml
@@ -1,0 +1,23 @@
+version: 1
+task_definition:
+  ecs_network_mode: none
+  task_role_arn: arn:aws:iam::506367651493:role/orbs-network 
+  memory: 2048
+  memoryReservation: 2048
+  task_size:
+    cpu_limit: 256
+    mem_limit: 2048
+  services:
+    orbs-network:
+      essential: true
+
+
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - subnet-47c6c30f
+        - subnet-56ebf130
+      # security_groups:
+      #   -	sg-824952fe
+      assign_public_ip: DISABLED


### PR DESCRIPTION
Run `orbs-network` container on ECS.

Next step would be scaling and discovery in a common network with ability to scale up and down.