### PR TITLE
Issue fix: Transactions proposed to non-leader nodes are not processed

### DIFF
--- a/config/topologies/transaction-gossip/node2/public-api.json
+++ b/config/topologies/transaction-gossip/node2/public-api.json
@@ -10,7 +10,7 @@
     },
     {
       "service": "consensus",
-      "endpoint": "0.0.0.0:51154"
+      "endpoint": "0.0.0.0:51254"
     },
     {
       "service": "virtual-machine",

--- a/projects/consensus-service-typescript/src/pbft-consensus.ts
+++ b/projects/consensus-service-typescript/src/pbft-consensus.ts
@@ -18,7 +18,7 @@ export default class PbftConsensus {
       this.gossip.unicastMessage({
         Recipient: leader,
         BroadcastGroup: "consensus",
-        MessageType: "SendTransactionInput",
+        MessageType: "Transaction",
         Buffer: new Buffer(JSON.stringify({transaction: tx, transactionAppendix: txAppendix})),
         Immediate: true});
     }


### PR DESCRIPTION
There was a mismatch in the message type sent to the leader for further handling. 