### PR TITLE
Fix VM client namespace

### DIFF
--- a/projects/common-library-typescript/src/grpc.ts
+++ b/projects/common-library-typescript/src/grpc.ts
@@ -81,7 +81,7 @@ export namespace grpc {
   }
 
   export function virtualMachineClient({ endpoint }: { endpoint: string }): types.VirtualMachineClient {
-    return client("vm.proto", "VirtualMachine", endpoint);
+    return client("virtual-machine.proto", "VirtualMachine", endpoint);
   }
 
   export function stateStorageClient({ endpoint }: { endpoint: string }): types.StateStorageClient {


### PR DESCRIPTION
```
TypeError: Cannot read property 'ns' of null
    at Object.load (/Users/kirill/GitHub/orbs-network/projects/common-library-typescript/node_modules/grpc/index.js:146:29)
    at caller (/Users/kirill/GitHub/orbs-network/projects/common-library-typescript/node_modules/grpc-caller/index.js:34:25)
    at client (/Users/kirill/GitHub/orbs-network/projects/common-library-typescript/src/grpc.ts:11:12)
    at Object.virtualMachineClient (/Users/kirill/GitHub/orbs-network/projects/common-library-typescript/src/grpc.ts:89:12)
    at Object.topologyPeers (/Users/kirill/GitHub/orbs-network/projects/common-library-typescript/src/topologyPeers.ts:29:35)
    at new PbftConsensus (/Users/kirill/GitHub/orbs-network/projects/consensus-service-typescript/src/pbft-consensus.ts:18:16)
    at new ConsensusService (/Users/kirill/GitHub/orbs-network/projects/consensus-service-typescript/src/service.ts:7:15)
    at Object.<anonymous> (/Users/kirill/GitHub/orbs-network/projects/consensus-service-typescript/src/index.ts:6:12)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
```