### PR TITLE
.editorconfig and recommended extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+charset = utf-8
+max_line_length = 180
+
+[*.ts]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ yarn.lock
 # Editors
 .idea
 .history
-.vscode
+.vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
 *.iml
 
 # OS metadata

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,20 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"DavidAnson.vscode-markdownlint",
+		"EditorConfig.EditorConfig",
+		"JuanBlanco.solidity",
+		"PeterJausovec.vscode-docker",
+		"christian-kohler.npm-intellisense",
+		"christian-kohler.path-intellisense",
+		"dbaeumer.vscode-eslint",
+		"eg2.tslint",
+		"eg2.vscode-npm-script",
+		"felipe.nasc-touchbar",
+		"ms-vscode.cpptools",
+		"wayou.vscode-todo-highlight",
+		"yzhang.markdown-all-in-one",
+		"zxh404.vscode-proto3",
+	]
+}


### PR DESCRIPTION
This PR adds two quasi-related files:
* `.editorconfig` file for cross-project editor settings such as ident size
* .vscode/extensions.json, which is deliberately exempt from `.gitignore` so that new team members could install all extensions we use automatically
