### PR TITLE
Clean up .env

### DIFF
--- a/deploy/bootstrap/.env
+++ b/deploy/bootstrap/.env
@@ -1,8 +1,6 @@
 # THIS FILE IS FOR STAGING ENV **ONLY** AND SHOULD BE CHANGED IN PRODUCTION
 LOG_LEVEL=debug
 GOSSIP_PEERS=ws://us-east-1.global.nodes.staging.orbs-test.com:60001,ws://eu-central-1.global.nodes.staging.orbs-test.com:60001,ws://ap-northeast-1.global.nodes.staging.orbs-test.com:60001,ws://ap-northeast-2.global.nodes.staging.orbs-test.com:60001,ws://ap-southeast-2.global.nodes.staging.orbs-test.com:60001,ws://ca-central-1.global.nodes.staging.orbs-test.com:60001
-E2E_PUBLIC_API_ENDPOINT=0.0.0.0:51151
-E2E_NO_DEPLOY=true
 NUM_OF_NODES=6
 # Should NOT be enabled in production
 SMART_CONTRACTS_TO_LOAD=[{"address": "foobar", "filename": "foobar-smart-contract"},{"address": "text-message", "filename": "text-message-smart-contract"}]


### PR DESCRIPTION
Since we don't run e2e from production tests for quite some time, we don't need these variables.