### PR TITLE
Fix e2e testnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: ./.circleci/setup-rngd.sh
       - run: $(aws ecr get-login --no-include-email --region us-west-2)
       - run: ./.circleci/docker-pull.sh
       - run: ./docker/build-sdk-base.sh
@@ -51,7 +50,8 @@ jobs:
     steps:
       - checkout
       - run: $(aws ecr get-login --no-include-email --region us-west-2)
-      - run: ./.circleci/docker-pull.sh
+      - run: ./docker/build-sdk-base.sh
+      - run: ./docker/build-e2e.sh
       - run: ./.circleci/e2e-testnet.sh
 
 workflows:

--- a/.circleci/e2e-testnet.sh
+++ b/.circleci/e2e-testnet.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -xe
 
-export DOCKER_TAG=$(./docker-tag.sh)
-
 docker run --rm -ti \
     -e E2E_NO_DEPLOY=true \
     -e E2E_PUBLIC_API_ENDPOINT=$E2E_PUBLIC_API_ENDPOINT \
-    $DOCKER_IMAGE:$DOCKER_TAG \
-    bash -c "cd e2e && ./build.sh && ./test-from-host.sh"
+    orbs:e2e \
+    ./test-from-host.sh


### PR DESCRIPTION
Fixes e2e test that is supposed to run on testnet. It will still fail, but because the testnet is not operational, not because I forgot to update build instructions during refactoring.

https://circleci.com/gh/orbs-network/orbs-network/1499