### PR TITLE
fixed deduplication problem with pending transaction pool

### DIFF
--- a/projects/libs/core-library-typescript/src/transaction-pool/pending-transaction-pool.ts
+++ b/projects/libs/core-library-typescript/src/transaction-pool/pending-transaction-pool.ts
@@ -82,14 +82,10 @@ export class PendingTransactionPool extends BaseTransactionPool {
     }
 
     if (!this.transactionValidator.validate(transaction)) {
-      throw new Error(`transaction ${JSON.stringify(transaction)} is not valid. not storing in the pool`);
+      throw new Error(`Transaction ${JSON.stringify(transaction)} is not valid. not storing in the pool`);
     }
+
     const txid = new TransactionHelper(transaction).calculateTransactionId();
-
-    if (this.pendingTransactions.has(txid)) {
-      throw new Error(`Transaction with id ${txid} already exists in the transaction pool`);
-    }
-
     this.pendingTransactions.set(txid, transaction);
 
     logger.debug(`Added a new transaction ${JSON.stringify(transaction)} to the pool`);

--- a/projects/libs/core-library-typescript/test/transaction-pool/pending-transaction-pool.spec.ts
+++ b/projects/libs/core-library-typescript/test/transaction-pool/pending-transaction-pool.spec.ts
@@ -66,15 +66,6 @@ describe("Transaction Pool", () => {
     expect(transactionEntries).to.have.lengthOf(0);
   });
 
-
-  it("two identical transactions are processed only once", async () => {
-    const tx = aValidTransaction();
-    const txid = await transactionPool.addNewPendingTransaction(tx);
-    await expect(transactionPool.addNewPendingTransaction(tx)).to.eventually.be.rejectedWith(
-      `Transaction with id ${txid} already exists in the transaction pool`
-    );
-  });
-
   it("expired transaction is not added to the pool", async () => {
     const tx = anExpiredTransaction();
     await expect(transactionPool.addNewPendingTransaction(tx)).to.be.rejected;

--- a/projects/services/consensus-service-typescript/src/transaction-pool-service.ts
+++ b/projects/services/consensus-service-typescript/src/transaction-pool-service.ts
@@ -4,7 +4,7 @@ import { types, logger, JsonBuffer } from "orbs-core-library";
 
 import { Service, ServiceConfig, TransactionHelper } from "orbs-core-library";
 import { PendingTransactionPool, CommittedTransactionPool } from "orbs-core-library";
-import { TransactionStatus } from "orbs-interfaces";
+import { TransactionStatus, Transaction } from "orbs-interfaces";
 
 export default class TransactionPoolService extends Service {
   private pendingTransactionPool: PendingTransactionPool;
@@ -48,6 +48,17 @@ export default class TransactionPoolService extends Service {
     }
   }
 
+  private validateTransactionUniqueOrThrow(transaction: Transaction): boolean {
+    const txid = new TransactionHelper(transaction).calculateTransactionId();
+    if (this.pendingTransactionPool.hasTransactionWithId(txid)) {
+      throw new Error(`Transaction with id ${txid} already exists in the pending transaction pool`);
+    } else if (this.committedTransactionPool.hasTransactionWithId(txid)) {
+      throw new Error(`Transaction with id ${txid} already exists in the committed transaction pool`);
+    } else {
+      return true;
+    }
+  }
+
   @Service.RPCMethod
   public async markCommittedTransactions(rpc: types.MarkCommittedTransactionsContext) {
     this.committedTransactionPool.addCommittedTransactions(rpc.req.transactionReceipts);
@@ -57,8 +68,10 @@ export default class TransactionPoolService extends Service {
 
   @Service.RPCMethod
   public async addNewPendingTransaction(rpc: types.AddNewPendingTransactionContext) {
-     const res = await this.pendingTransactionPool.addNewPendingTransaction(rpc.req.transaction);
-     rpc.res = { txid: res };
+    if (this.validateTransactionUniqueOrThrow(rpc.req.transaction)) {
+      const res = await this.pendingTransactionPool.addNewPendingTransaction(rpc.req.transaction);
+      rpc.res = { txid: res };
+    }
   }
 
   @Service.RPCMethod
@@ -82,16 +95,9 @@ export default class TransactionPoolService extends Service {
     if (rpc.req.messageType === "newTransaction") {
       const obj: any = JsonBuffer.parseJsonWithBuffers(rpc.req.buffer.toString("utf8"));
       const message = <types.NewTransactionBroadcastMessage>obj;
-      const txid = new TransactionHelper(message.transaction).calculateTransactionId();
-      if (this.pendingTransactionPool.hasTransactionWithId(txid)) {
-        throw new Error(`Transaction with id ${txid} already exists in the pending transaction pool`);
-      } else if (this.committedTransactionPool.hasTransactionWithId(txid)) {
-        throw new Error(`Transaction with id ${txid} already exists in the committed transaction pool`);
-      } else {
+      if (this.validateTransactionUniqueOrThrow(message.transaction)) {
         await this.pendingTransactionPool.onNewBroadcastTransaction(message.transaction);
       }
     }
   }
-
-
 }

--- a/projects/services/consensus-service-typescript/test/transaction-pool-service.spec.ts
+++ b/projects/services/consensus-service-typescript/test/transaction-pool-service.spec.ts
@@ -46,6 +46,15 @@ function createGossipMessagePayload(transaction?: Transaction): GossipListenerIn
     };
 }
 
+function createTransactionReceipt(transaction: Transaction): TransactionReceipt {
+    const helper = new TransactionHelper(transaction);
+    const txHash = helper.calculateHash();
+    const receipt: types.TransactionReceipt = {
+      txHash,
+      success: true
+    };
+    return receipt;
+}
 
 describe("transaction pool service tests", function() {
     let server: GRPCServerBuilder;
@@ -148,7 +157,7 @@ describe("transaction pool service tests", function() {
         expect(transaction).to.have.property("transaction").that.has.property("payload", DUMMY_TRANSACTION_PAYLOAD);
     });
 
-    it("service handles de-duplication of transactions which are already pending", async () => {
+    it("service handles de-duplication of transactions which are already pending (gossip flow)", async () => {
         const transaction = createDummyTransaction();
         const txid = (await client.addNewPendingTransaction({ transaction })).txid;
         await expect(client.gossipMessageReceived(createGossipMessagePayload(transaction))).to.eventually.be.rejectedWith(
@@ -156,18 +165,30 @@ describe("transaction pool service tests", function() {
         );
     });
 
-    it("service handles de-duplication of transactions which are already committed", async () => {
+    it("service handles de-duplication of transactions which are already pending (api flow)", async () => {
         const transaction = createDummyTransaction();
         const txid = (await client.addNewPendingTransaction({ transaction })).txid;
-        const helper = new TransactionHelper(transaction);
-        const txHash = helper.calculateHash();
-        const receipt: types.TransactionReceipt = {
-          txHash,
-          success: true
-        };
+        await expect(client.addNewPendingTransaction({ transaction })).to.eventually.be.rejectedWith(
+            `Transaction with id ${txid} already exists in the pending transaction pool`
+        );
+    });
 
+    it("service handles de-duplication of transactions which are already committed (gossip flow)", async () => {
+        const transaction = createDummyTransaction();
+        const txid = (await client.addNewPendingTransaction({ transaction })).txid;
+        const receipt = createTransactionReceipt(transaction);
         await client.markCommittedTransactions({transactionReceipts: [ receipt ]});
         await expect(client.gossipMessageReceived(createGossipMessagePayload(transaction))).to.eventually.be.rejectedWith(
+            `Transaction with id ${txid} already exists in the committed transaction pool`
+        );
+    });
+
+    it("service handles de-duplication of transactions which are committed and then readded via addNewPending (api flow)", async () => {
+        const transaction = createDummyTransaction();
+        const txid = (await client.addNewPendingTransaction({ transaction })).txid;
+        const receipt = createTransactionReceipt(transaction);
+        await client.markCommittedTransactions({transactionReceipts: [ receipt ]});
+        await expect(client.addNewPendingTransaction({ transaction })).to.eventually.be.rejectedWith(
             `Transaction with id ${txid} already exists in the committed transaction pool`
         );
     });


### PR DESCRIPTION
the pools are unaware of each-other (pending, committed)
service handles dedup
there was a bug in the api flow (directly calling addNewPending() )
removed the test from pending logic which checks dedup - the pool itself should not test that, the service should (and is now)
added tests at the service for testing the missing flow
