### PR TITLE
Fix stub consensus

### DIFF
--- a/deploy/bootstrap/docker-compose.yml
+++ b/deploy/bootstrap/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       BLOCK_SIZE_LIMIT: 2000
       VERIFY_TRANSACTION_SIGNATURES: 'true'
       VERIFY_SUBSCRIPTION: 'false'
+      CONSENSUS_ALGORITHM: 'stub'
+      CONSENSUS_LEADER_NODE_NAME: 'orbs-global-506367651493-staging-ap-northeast-1'
     volumes:
       - /mnt/data/logs:/opt/orbs/logs
       - /opt/orbs/private-keys/block:/opt/orbs/private-keys/block
@@ -114,5 +116,3 @@ services:
 networks:
   default:
     driver: bridge
-
-# Touch

--- a/e2e/config/docker/docker-compose.test.services.yml
+++ b/e2e/config/docker/docker-compose.test.services.yml
@@ -20,6 +20,8 @@ services:
       - MSG_LIMIT=4000000
       - BLOCK_SIZE_LIMIT=2000
       - LEADER_SYNC_INTERVAL=100
+      - CONSENSUS_ALGORITHM=stub
+      - CONSENSUS_LEADER_NODE_NAME=node2
 
     ports:
       - ${DEBUG_PORT}:9229


### PR DESCRIPTION
Stub consensus does not take into account the fact that if we're starting from block height > 0 this height will never be reported and the leader will always think it's out of sync with the followers, therefore never producing a block.