### PR TITLE
Fix/e2e fail on unhealthy dockers

### DIFF
--- a/e2e/src/docker-health-checks.ts
+++ b/e2e/src/docker-health-checks.ts
@@ -38,11 +38,12 @@ export async function runDockerHealthCheck(maxRetries: number = 12, intervalSec:
   }
 
   if (unhealthyContainers.length > 0) {
-    console.log("Still have unhealthy nodes:");
-    _.map(unhealthyContainers, console.log);
+    const errmsg = `Still have unhealthy nodes: ${JSON.stringify(unhealthyContainers)}`;
+    console.log(errmsg);
+    throw new Error(errmsg);
   }
 
-  return unhealthyContainers;
+  return true;
 }
 
 function runDockerHealthCheckOnce(): Promise<string[]> {

--- a/e2e/src/simple-smart-contracts.spec.ts
+++ b/e2e/src/simple-smart-contracts.spec.ts
@@ -54,7 +54,12 @@ describe("simple token transfer", async function () {
     if (testConfig.testEnvironment) {
       console.log("starting test environment...");
       await testConfig.testEnvironment.start();
-      await runDockerHealthCheck(DOCKER_HEALTH_CHECK_MAX_RETRIES, DOCKER_HEALTH_CHECK_RETRY_INTERVAL_SEC);
+      try {
+        await runDockerHealthCheck(DOCKER_HEALTH_CHECK_MAX_RETRIES, DOCKER_HEALTH_CHECK_RETRY_INTERVAL_SEC);
+      } catch (e) {
+        console.log(`Error in Docker health check, not all docker containers are not healthy and all retry attempts exhaused`);
+        throw e;
+      }
     }
   });
 

--- a/e2e/src/simple-smart-contracts.spec.ts
+++ b/e2e/src/simple-smart-contracts.spec.ts
@@ -47,7 +47,8 @@ async function aTextMessageAccount(networkId: string) {
   return account;
 }
 
-describe("simple token transfer", async function () {
+describe("transfer tokens and messages between accounts", async function () {
+
   this.timeout(800000);
 
   before(async () => {
@@ -63,7 +64,7 @@ describe("simple token transfer", async function () {
     }
   });
 
-  it("transfers 1 bar token from one account to another", async () => {
+  it("should transfer 1 bar token from one account to another", async () => {
     console.log("initing account1 with 2 bars");
     const account1 = await aFooBarAccountWith({ amountOfBars: 2, networkId: testConfig.networkId });
     await account1.should.have.bars(2);
@@ -76,20 +77,8 @@ describe("simple token transfer", async function () {
     await account1.should.to.have.bars(1);
     await account2.should.have.bars(1);
   });
-});
 
-describe("simple message", async function () {
-  this.timeout(800000);
-
-  before(async () => {
-    if (testConfig.testEnvironment) {
-      console.log("starting test environment...");
-      await testConfig.testEnvironment.start();
-    }
-  });
-
-
-  it("sends text messages between accounts", async () => {
+  it("should send text message from one account to another", async () => {
     console.log("Initiating account for Alice");
     const alice = await aTextMessageAccount(testConfig.networkId);
 
@@ -113,11 +102,10 @@ describe("simple message", async function () {
     expect(aliceMessages[0].message).to.equal("is anybody in here?");
   });
 
-
-
   after(async () => {
     if (testConfig.testEnvironment) {
       await testConfig.testEnvironment.stop();
     }
   });
+
 });


### PR DESCRIPTION
Failing the e2e tests if not all docker containers are healthy after all health check retries are completed. Reordered e2e tests so there is a single describe() with 2 it() tests.