### PR TITLE
Don't log health check if status=OK

### DIFF
--- a/projects/libs/core-library-typescript/src/common-library/startup-check-runner.ts
+++ b/projects/libs/core-library-typescript/src/common-library/startup-check-runner.ts
@@ -18,7 +18,9 @@ export class StartupCheckRunner {
     return Promise.all(startupCheckPromises)
       .then(statuses => {
         const mergedStartupStatus = this.mergeStartupStatuses(this.name, statuses);
-        logger.info("Health check", _.cloneDeep(mergedStartupStatus)); // mergedStartupStatus is mutated inside logger.info, so cloned
+        if (mergedStartupStatus.status !== STARTUP_STATUS.OK) {
+          logger.info("Health check", _.cloneDeep(mergedStartupStatus)); // mergedStartupStatus is mutated inside logger.info, so cloned
+        }
         return mergedStartupStatus;
       })
       .catch(err => {


### PR DESCRIPTION
This prevents flooding the logger with status=OK messages from Docker health check.